### PR TITLE
Make response time of the example server more interesting.

### DIFF
--- a/server.py
+++ b/server.py
@@ -7,11 +7,14 @@ from BaseHTTPServer import BaseHTTPRequestHandler
 from BaseHTTPServer import HTTPServer
 from SocketServer import ThreadingMixIn
 
+start = time.time()
 
-def generate_request_handler(average_latency_seconds, error_ratio):
+def generate_request_handler(average_latency_seconds, error_ratio, outage_duration_seconds):
     def f(self):
-        time.sleep(max(0, average_latency_seconds + random.normalvariate(.01, .01)))
-        if random.random() < error_ratio:
+        in_outage = (time.time() - start) % (10 * outage_duration_seconds) < outage_duration_seconds
+        sleep_time = max(0, random.normalvariate(average_latency_seconds, average_latency_seconds/10))
+        time.sleep(sleep_time * (3 if in_outage else 1))
+        if random.random() < error_ratio * (10 if in_outage else 1):
             self.send_response(500)
         else:
             self.send_response(200)
@@ -25,10 +28,10 @@ def handler_404(self):
 ROUTES = {
     ('GET', "/"): lambda self: self.wfile.write("Hello World!"),
     ('GET', "/favicon.ico"): lambda self: self.send_response(404),
-    ('GET', "/api/foo"): generate_request_handler(.01, .005),
-    ('POST', "/api/foo"): generate_request_handler(.02, .02),
-    ('GET', "/api/bar"): generate_request_handler(.015, .00025),
-    ('POST', "/api/bar"): generate_request_handler(.05, .01),
+    ('GET', "/api/foo"): generate_request_handler(.01, .005, 23.0),
+    ('POST', "/api/foo"): generate_request_handler(.02, .02, 60.0),
+    ('GET', "/api/bar"): generate_request_handler(.015, .00025, 13.0),
+    ('POST', "/api/bar"): generate_request_handler(.05, .01, 47.0),
 }
 
 class Handler(BaseHTTPRequestHandler):


### PR DESCRIPTION
Make sigma depend on the average latency.

Create periodic "outages" with `10*error_ratio` and `3*latency`.

Without the latter, latency graphs will just by flat lines.

@brian-brazil We'll conduct a workshop at each of the upcoming velocities. So I thought it's a good time to spice this up.
